### PR TITLE
Ajout des champs manquants pour le modèle d'issue

### DIFF
--- a/.github/ISSUE_TEMPLATE/nouvelle-issue.md
+++ b/.github/ISSUE_TEMPLATE/nouvelle-issue.md
@@ -1,5 +1,10 @@
 ---
 name: Nouvelle issue
+about: Modèle pour les nouvelles issues
+title: ''
+labels: ''
+assignees: ''
+
 ---
 
 # CONTEXTE


### PR DESCRIPTION
Ajout des champs requis pour les modèles d'issue.
Les champs "about", "title", "labels" et "assignees" ont été ajoutés.

Close #6 